### PR TITLE
feat: 글 저장 기능 구현 및 관련 테스트 코드 추가

### DIFF
--- a/src/main/kotlin/com/stress/resolve/controller/PostController.kt
+++ b/src/main/kotlin/com/stress/resolve/controller/PostController.kt
@@ -1,6 +1,7 @@
 package com.stress.resolve.controller
 
 import com.stress.resolve.request.PostCreate
+import com.stress.resolve.service.PostService
 import io.github.oshai.kotlinlogging.KotlinLogging
 import jakarta.validation.Valid
 import org.springframework.web.bind.annotation.PostMapping
@@ -10,16 +11,12 @@ import org.springframework.web.bind.annotation.RestController
 private val logger = KotlinLogging.logger {  }
 
 @RestController
-class PostController {
+class PostController(
+    private val postService: PostService
+) {
 
     @PostMapping("/posts")
-    fun post(@RequestBody @Valid request: PostCreate): Map<String, String> {
-        val result = mutableMapOf<String, String>()
-        /* 1. BindingResult를 파라미터로 받으면 ControllerAdvice 전에 먼저 걸리게 된다. */
-//        if(bindingResult.hasErrors()) {
-//            bindingResult.fieldErrors.forEach { error -> result[error.field] = error.defaultMessage ?: "" }
-//        }
-        /* 2. 응답 클래스로 Map을 리턴하기보다는, 응답 클래스를 만들어주는 것이 좋다. */
-        return result
+    fun post(@RequestBody @Valid request: PostCreate) {
+        postService.write(request)
     }
 }

--- a/src/main/kotlin/com/stress/resolve/domain/Post.kt
+++ b/src/main/kotlin/com/stress/resolve/domain/Post.kt
@@ -1,0 +1,22 @@
+package com.stress.resolve.domain
+
+import jakarta.persistence.*
+
+@Entity
+class Post(
+    title: String,
+    content: String,
+) {
+    @Column(nullable = false)
+    var title: String = title
+        protected set
+
+    @Lob
+    @Column(nullable = false)
+    var content: String = content
+        protected set
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private val id: Long? = null
+}

--- a/src/main/kotlin/com/stress/resolve/repository/PostRepository.kt
+++ b/src/main/kotlin/com/stress/resolve/repository/PostRepository.kt
@@ -1,0 +1,6 @@
+package com.stress.resolve.repository
+
+import com.stress.resolve.domain.Post
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface PostRepository: JpaRepository<Post, Long>

--- a/src/main/kotlin/com/stress/resolve/service/PostService.kt
+++ b/src/main/kotlin/com/stress/resolve/service/PostService.kt
@@ -1,0 +1,22 @@
+package com.stress.resolve.service
+
+import com.stress.resolve.domain.Post
+import com.stress.resolve.repository.PostRepository
+import com.stress.resolve.request.PostCreate
+import io.github.oshai.kotlinlogging.KotlinLogging
+import jakarta.transaction.Transactional
+import org.springframework.stereotype.Service
+
+private val logger = KotlinLogging.logger { }
+
+@Service
+class PostService(
+    private val postRepository: PostRepository
+) {
+
+    @Transactional
+    fun write(postCreate: PostCreate) {
+        val post = Post(title = postCreate.title, content = postCreate.content)
+        postRepository.save(post)
+    }
+}

--- a/src/test/kotlin/com/stress/resolve/controller/PostControllerTest.kt
+++ b/src/test/kotlin/com/stress/resolve/controller/PostControllerTest.kt
@@ -1,19 +1,36 @@
 package com.stress.resolve.controller
 
+import com.stress.resolve.repository.PostRepository
+import jakarta.transaction.Transactional
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.http.MediaType
+import org.springframework.http.MediaType.APPLICATION_JSON
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers.print
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
-@WebMvcTest
+//@WebMvcTest
+@SpringBootTest // 3-tier 테스트를 위한 애노테이션 추가
+@AutoConfigureMockMvc // mockMvc 주입을 위한 애노테이션 추가
 class PostControllerTest {
+
     @Autowired
     private lateinit var mockMvc: MockMvc
+
+    @Autowired
+    private lateinit var postRepository: PostRepository
+
+    @BeforeEach
+    fun cleanUp() {
+        postRepository.deleteAll()
+    }
 
     @Test
     fun `POST 요청 전송 시 title값은 필수이다`() {
@@ -29,5 +46,21 @@ class PostControllerTest {
             .andExpect(jsonPath("$..title").value("제목은 빈값이 올 수 없습니다!"))
             .andExpect(jsonPath("$..content").value("내용은 빈값이 올 수 없습니다!"))
             .andDo(print())
+    }
+
+    @Test
+    fun `정상 POST 요청 시 DB에 값을 저장한다`() {
+        // given
+        assertThat(postRepository.count()).isEqualTo(0L)
+
+        // when
+        mockMvc.perform(post("/posts").contentType(APPLICATION_JSON).content("{\"title\" : \"제목입니다.\", \"content\" : \"내용입니다.\"}"))
+            .andExpect(status().isOk)
+            .andDo(print())
+
+        // then
+        assertThat(postRepository.count()).isEqualTo(1L)
+        assertThat(postRepository.findAll()).extracting("title").containsExactly("제목입니다.")
+        assertThat(postRepository.findAll()).extracting("content").containsExactly("내용입니다.")
     }
 }


### PR DESCRIPTION
### 글 저장 기능 구현 및 관련 테스트 코드 추가 PR

```kotlin
interface PostRepository: JpaRepository<Post, Long>
```
`JpaRepository`를 구현한 PostRepository

<br/>

```kotlin
@Service
class PostService(
    private val postRepository: PostRepository
) {

    @Transactional
    fun write(postCreate: PostCreate) {
        val post = Post(title = postCreate.title, content = postCreate.content)
        postRepository.save(post)
    }
}
```

`PostCreate` DTO 요청을 받아 Post 저장