### PR TITLE
feat: 모든 게시글 조회 API 생성 및 테스트코드 추가

### DIFF
--- a/src/main/kotlin/com/stress/resolve/controller/PostController.kt
+++ b/src/main/kotlin/com/stress/resolve/controller/PostController.kt
@@ -24,6 +24,9 @@ class PostController(
         postService.write(request)
     }
 
+    @GetMapping("/posts")
+    fun getAll() = postService.getAll()
+
     @GetMapping("/posts/{postId}")
     fun get(@PathVariable(value = "postId") id: Long): PostResponse =
         postService.get(id)

--- a/src/main/kotlin/com/stress/resolve/domain/Post.kt
+++ b/src/main/kotlin/com/stress/resolve/domain/Post.kt
@@ -1,5 +1,6 @@
 package com.stress.resolve.domain
 
+import com.stress.resolve.response.PostResponse
 import jakarta.persistence.*
 
 @Entity
@@ -19,4 +20,10 @@ class Post(
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)
     val id: Long? = null
+
+    companion object {
+        // Post -> PostResponse
+        fun response(post: Post): PostResponse =
+            PostResponse(id = post.id!!, originalTitle = post.title, content = post.content)
+    }
 }

--- a/src/main/kotlin/com/stress/resolve/service/PostService.kt
+++ b/src/main/kotlin/com/stress/resolve/service/PostService.kt
@@ -15,11 +15,15 @@ class PostService(
 
     @Transactional
     fun write(postCreate: PostCreate) {
-        Post(title = postCreate.title, content = postCreate.content).also { postRepository.save(it) }
+        val post = Post(title = postCreate.title, content = postCreate.content)
+        postRepository.save(post)
     }
+
+    fun getAll(): List<PostResponse> =
+        postRepository.findAll().map { Post.response(it) }
 
     fun get(id: Long): PostResponse {
         val post = postRepository.findByIdOrNull(id) ?: throw IllegalArgumentException("존재하지 않는 글입니다!")
-        return PostResponse(id = post.id!!, originalTitle = post.title, content = post.content)
+        return Post.response(post)
     }
 }

--- a/src/test/kotlin/com/stress/resolve/controller/PostControllerTest.kt
+++ b/src/test/kotlin/com/stress/resolve/controller/PostControllerTest.kt
@@ -67,8 +67,11 @@ class PostControllerTest {
 
         // when
         val request = PostCreate(title = "제목입니다.", content = "내용입니다.")
-        mockMvc.perform(post("/posts").contentType(APPLICATION_JSON).content(
-            mapper.writeValueAsString(request)))
+        mockMvc.perform(
+            post("/posts").contentType(APPLICATION_JSON).content(
+                mapper.writeValueAsString(request)
+            )
+        )
             .andExpect(status().isOk)
             .andDo(print())
 
@@ -100,6 +103,20 @@ class PostControllerTest {
         mockMvc.perform(get("/posts/{postId}", post.id).contentType(APPLICATION_JSON))
             .andExpect(status().isOk)
             .andExpect(jsonPath("$.title").value("10글자가 넘는 제..."))
+            .andDo(print())
+    }
+
+    @Test
+    fun `posts GET요청으로 모든 글을 조회한다`() {
+        // given
+        repeat(3) { postRepository.save(Post(title = "제목입니다 ${it + 1}", content = "내용입니다 ${it + 1}")) }
+
+        // when & then
+        mockMvc.perform(get("/posts").contentType(APPLICATION_JSON))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.size()").value(3))
+            .andExpect(jsonPath("$.*.title", Matchers.containsInAnyOrder("제목입니다 1", "제목입니다 2", "제목입니다 3")))
+            .andExpect(jsonPath("$.[0].content").value("내용입니다 1")) // value()는 단일값에 대한 검증을 할때 주로 사용
             .andDo(print())
     }
 }

--- a/src/test/kotlin/com/stress/resolve/service/PostServiceTest.kt
+++ b/src/test/kotlin/com/stress/resolve/service/PostServiceTest.kt
@@ -52,4 +52,18 @@ class PostServiceTest {
         assertThat(post.title).isEqualTo("제목입니다.")
         assertThat(post.content).isEqualTo("내용입니다.")
     }
+
+    @Test
+    fun `저장한 모든 글을 조회한다`() {
+        // given
+        repeat(3) { postRepository.save(Post(title = "제목입니다 ${it + 1}", content = "내용입니다 ${it + 1}"))}
+
+        // when
+        val posts = postService.getAll()
+
+        // then
+        assertThat(posts.size).isEqualTo(3)
+        assertThat(posts).extracting("title").containsExactly("제목입니다 1", "제목입니다 2", "제목입니다 3")
+        assertThat(posts).extracting("content").containsExactly("내용입니다 1", "내용입니다 2", "내용입니다 3")
+    }
 }


### PR DESCRIPTION
### 모든 게시글 조회 API 생성

```kotlin
// PostController.kt
@GetMapping("/posts")
    fun getAll() = postService.getAll()
```

모든 게시글 조회 API를 추가함 `GET /posts`

<br/>

### Entity -> DTO 편의 메소드 생성 

```kotlin
// Post.kt
companion object {
        // Post -> PostResponse
        fun response(post: Post): PostResponse =
            PostResponse(id = post.id!!, originalTitle = post.title, content = post.content)
    }
```

<img width="1299" alt="image" src="https://github.com/user-attachments/assets/2b21bfeb-1727-4508-81f2-5c23c7b4dcd3" />

또한 Entity -> DTO 편의 메소드를 companion object로 선언하여 적용함.

<br/>

### 테스트코드 추가

```kotlin
@Test
    fun `저장한 모든 글을 조회한다`() {
        // given
        repeat(3) { postRepository.save(Post(title = "제목입니다 ${it + 1}", content = "내용입니다 ${it + 1}"))}

        // when
        val posts = postService.getAll()

        // then
        assertThat(posts.size).isEqualTo(3)
        assertThat(posts).extracting("title").containsExactly("제목입니다 1", "제목입니다 2", "제목입니다 3")
        assertThat(posts).extracting("content").containsExactly("내용입니다 1", "내용입니다 2", "내용입니다 3")
    }
```

위에서 추가한 API 관련 Service, Controller 테스트 코드를 추가함